### PR TITLE
Fix dependancy of ipython, fix #107

### DIFF
--- a/pyluos/version.py
+++ b/pyluos/version.py
@@ -1,1 +1,1 @@
-version = '2.0.0'
+version = '2.0.1'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(name='pyluos',
                         'zeroconf',
                         'numpy',
                         'anytree',
-                        'crc8'
+                        'crc8',
+                        'ipython'
                         ],
       extras_require={
           'tests': ['pytest', 'flake8'],


### PR DESCRIPTION
Recently we add pyluos-shell based on ipython, but we miss to add the ipython dependency on pip.