### PR TITLE
Add timeout for device closing

### DIFF
--- a/pyluos/device.py
+++ b/pyluos/device.py
@@ -143,7 +143,10 @@ class Device(object):
 
     def close(self):
         self._running = False
-        self._poll_bg.join()
+        self._poll_bg.join(timeout=2.0)
+        if self._poll_bg.is_alive():
+            # _poll_bg didn't terminate within the timeout
+            print("Warning: device closed on timeout, background thread is still running.")
         self._io.close()
 
     @property


### PR DESCRIPTION
Allows script to terminate despite communication errors with the Luos network.
As this feature might hide some other problems, I added a warning message if the polling thread didn't terminate cleanly.