### PR TITLE
remove pyluos limitation to send messages without receiving a gate me…

### DIFF
--- a/pyluos/io/serial_io.py
+++ b/pyluos/io/serial_io.py
@@ -121,10 +121,6 @@ class Serial(IOHandler):
         while self._running:
             to_read = self._serial.in_waiting
 
-            if to_read == 0:
-                time.sleep(self.period)
-                continue
-
             s = self._serial.read(to_read)
             buff = buff + s
 

--- a/pyluos/io/ws.py
+++ b/pyluos/io/ws.py
@@ -63,7 +63,7 @@ class Ws(IOHandler):
 
     def recv(self):
         try:
-            data = self._msg.get(True, 1)
+            data = self._msg.get(block = False)
         except queue.Empty:
             data = None
         return data
@@ -73,7 +73,7 @@ class Ws(IOHandler):
 
     def close(self):
         self._running = False
-        self._poll_loop.join()
+        self._poll_loop.join(timeout = 1)
         self._ws.close()
 
     def _poll(self):
@@ -94,6 +94,8 @@ class Ws(IOHandler):
 
         while self._running:
             s = self._ws.recv()
+            if isinstance(s, str):
+                return
             buff = buff + s
             while self._running:
                 line, buff = extract_line(buff)


### PR DESCRIPTION
Remove pyluos need to receive à message from the gate to be allowed to send. 

Also fixes the closing of the communication by allowing the join method to timeout. 