### PR TITLE
Improve _last_update property

### DIFF
--- a/pyluos/device.py
+++ b/pyluos/device.py
@@ -111,7 +111,7 @@ class Device(object):
         self._setup()
         self.logger.info('Device setup.')
 
-        self._last_update = time.time()
+        self._last_update = 0.0
         self._running = True
         self._pause = False
 
@@ -220,6 +220,10 @@ class Device(object):
     def nodes(self):
         return nodeList(self._nodes)
 
+    @property
+    def last_update(self) -> float:
+        """The last_update property."""
+        return self._last_update
 
     # Poll state from hardware.
     def _poll_once(self):
@@ -299,7 +303,7 @@ class Device(object):
             if (self._freedomLink != None):
                 self._freedomLink._update(alias, mod)
 
-        self._last_update = time.time()
+        self._last_update = float(new_state["timestamp"])
 
     def update_cmd(self, alias, key, val):
         with self._cmd_lock:


### PR DESCRIPTION
The `_last_update` property of pyluos.Device was set but never used. I propose the following:

- initialize `_last_update` to `0.0` instead of `time.time()` to clearly show that no state has ever been received
- when a new state is received, set `_last_update` to the same value as `new_state["timestamp"]
- create a getter for `_last_update`

These modifications allow to simply and consistently check how long ago the last state was received.