### PR TITLE
New feature: push despite empty state

### DIFF
--- a/pyluos/device.py
+++ b/pyluos/device.py
@@ -87,7 +87,6 @@ class Device(object):
     def __init__(self, host,
                  IO=None,
                  log_conf=_base_log_conf,
-                 test_mode=False,
                  background_task=True,
                  *args, **kwargs):
         if IO is not None:

--- a/pyluos/device.py
+++ b/pyluos/device.py
@@ -88,6 +88,7 @@ class Device(object):
                  IO=None,
                  log_conf=_base_log_conf,
                  background_task=True,
+                 push_despite_empty_state=False,
                  *args, **kwargs):
         if IO is not None:
             self._io = IO(host=host, *args, **kwargs)
@@ -102,6 +103,8 @@ class Device(object):
 
         self.logger = logging.getLogger(__name__)
         self.logger.info('Connected to "{}".'.format(host))
+
+        self.__push_despite_empty_state = push_despite_empty_state
 
         self._send_lock = threading.Lock()
         self._cmd_lock = threading.Lock()
@@ -236,6 +239,7 @@ class Device(object):
                 state = self._poll_once()
                 if state:
                     self._update(state)
+                if state or self.__push_despite_empty_state:
                     self._push_once()
             else:
                 time.sleep(0.1)

--- a/pyluos/device.py
+++ b/pyluos/device.py
@@ -88,7 +88,6 @@ class Device(object):
                  IO=None,
                  log_conf=_base_log_conf,
                  background_task=True,
-                 push_despite_empty_state=False,
                  *args, **kwargs):
         if IO is not None:
             self._io = IO(host=host, *args, **kwargs)
@@ -103,8 +102,6 @@ class Device(object):
 
         self.logger = logging.getLogger(__name__)
         self.logger.info('Connected to "{}".'.format(host))
-
-        self.__push_despite_empty_state = push_despite_empty_state
 
         self._send_lock = threading.Lock()
         self._cmd_lock = threading.Lock()
@@ -239,8 +236,7 @@ class Device(object):
                 state = self._poll_once()
                 if state:
                     self._update(state)
-                if state or self.__push_despite_empty_state:
-                    self._push_once()
+                self._push_once()
             else:
                 time.sleep(0.1)
 


### PR DESCRIPTION
The new state was pushed (from PyLuos objects to Gate) only if the Gate had sent back a network state.

I propose to add a parameter to allow bypassing this, by pushing the changes made on PyLuos objects even when no new state has been received from the Gate. The parameter added is `push_despite_empty_state` in pyluos.device.Device constructor.

The default behavior is left unchanged.